### PR TITLE
Implement cookie support using cl-cookie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ lightweight cousin to [drakma-async](https://github.com/orthecreedence/drakma-as
 ### request (function)
 
 ```lisp
-(defun request (url &key (method :get) headers body return-body header-callback body-callback finish-callback (redirect 5) redirect-non-get timeout))
+(defun request (url &key (method :get) headers body cookie-jar return-body header-callback body-callback finish-callback (redirect 5) redirect-non-get timeout))
   => promise
 ```
 
@@ -26,6 +26,8 @@ that the "Host" header is set automatically (if not proveded) and if the `body`
 argument is passed, then "Content-Length" is set as well.
 - `body` - A string or byte array to send as the HTTP body. If present, will set
 the "Content-Length" header automatically in the request.
+- `cookie-jar` - A `cl-cookie` `cookie-jar`. Instantiate one with `(make-instance 'cookie:cookie-jar)`
+and pass it on every request on which cookie processing is to be enabled.
 - `return-body` - If T, will store the entire HTTP response body and finish the
 returned promise with it once complete. If this is left `nil`, then the first
 value of the finished promise will be `nil`.

--- a/carrier.asd
+++ b/carrier.asd
@@ -11,7 +11,8 @@
                #:blackbird
                #:quri
                #:fast-http
-               #:fast-io)
+               #:fast-io
+               #:cl-cookie)
   :components
   ((:file "package")
    (:file "util" :depends-on ("package"))

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,9 @@
 (defpackage :carrier
   (:use :cl :blackbird)
+  (:import-from :cl-cookie
+                :merge-cookies
+                :parse-set-cookie-header
+                :cookie-jar-host-cookies
+                :write-cookie-header)
   (:export #:request))
 


### PR DESCRIPTION
cl-cookie is Copyright (c) 2015 Eitaro Fukamachi (e.arrows@gmail.com)
and licensed under the BSD 2-Clause License.

Also contains a (MIT licensed as well) snippet from dexador. Will this require @fukamachi 's copyright line as well?

dexador is Copyright (c) 2015 Eitaro Fukamachi (e.arrows@gmail.com)
and licensed under the MIT License.