### PR TITLE
Resolve list instead of individual values.

### DIFF
--- a/carrier.lisp
+++ b/carrier.lisp
@@ -128,7 +128,7 @@
                                     (let ((body (when return-body
                                                   (fast-io:finish-output-buffer body-buffer)))
                                           (status (fast-http:http-status http)))
-                                      (resolve body status response-headers)))))
+                                      (resolve (list body status response-headers))))))
            (parser (fast-http:make-parser http
                                           :header-callback our-header-callback
                                           :body-callback our-body-callback


### PR DESCRIPTION
I can't get the HTTP status code from carrier, it would either give me the body or nil i.e. the first value in the resolve call instead of all 3 values in a list.

Below is a snippet showing the issue:

```lisp
(ql:quickload '(:cl-async :blackbird :carrier))

(as:with-event-loop ()
    (blackbird:catcher
     (blackbird:alet ((resp (carrier:request "http://www.google.com.au")))
       (format t "Response Code: ~A~%" (second resp)))
     (t (e)
        (format t "Caught Promise error: ~A~%" e))))
```
this was on sbcl 2.0.10
