### PR TITLE
Added HEAD indication to fast-http call.

### DIFF
--- a/carrier.lisp
+++ b/carrier.lisp
@@ -132,7 +132,8 @@
            (parser (fast-http:make-parser http
                                           :header-callback our-header-callback
                                           :body-callback our-body-callback
-                                          :finish-callback our-finish-callback))
+                                          :finish-callback our-finish-callback
+					  :head-request (eq method :head)))
            (request-data (build-request parsed method headers body cookie-jar))
            (connect-fn (if (string= (quri:uri-scheme parsed) "https")
                            'as-ssl:tcp-ssl-connect


### PR DESCRIPTION
Fast-http needs to be told when it should be expecting a HEAD response.

This is the other side of the following PR in fast-http https://github.com/fukamachi/fast-http/pull/43

I am using HEAD requests to check for updates, but some servers return payload headers like Content-Length in a HEAD response, making determining if there should be a body following the headers difficult, so fast-http now lets you tell it to expect a HEAD response.